### PR TITLE
Update project headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/sailtrack-logo.svg" width="180">
 </p>
 
-<h3 class="readme-header" align="center">Sailing Performance Tracker built by the Metis Sailing Team</h3>
+<h3 class="readme-header" align="center">Performance Tracker for Racing Sailboats</h3>
 <p class="readme-header" align="center">
   <img src="https://img.shields.io/github/license/metisvela/sailtrack">
   <img src="https://img.shields.io/github/stars/metisvela/sailtrack">


### PR DESCRIPTION
Our current headline doesn't really deliver what the project is about and instead emphasizes the fact that the project is built by the Metis Sailing Team. I propose to change it to a more descriptive and shorter one that solely focuses on what the project is. The fact that the project is built by the Metis Sailing Team is included in the introduction anyway.